### PR TITLE
Added support for standalone Eloquent

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,8 @@
   "require": {
     "php": ">= 5.5.9",
     "illuminate/database": ">= 5.2",
-    "illuminate/support": ">= 5.2"
+    "illuminate/support": ">= 5.2",
+    "illuminate/events": "^5.8"
   },
   "require-dev": {
     "mockery/mockery": "0.9.*|~1.0",

--- a/src/SingleTableInheritanceTrait.php
+++ b/src/SingleTableInheritanceTrait.php
@@ -2,6 +2,8 @@
 
 namespace Nanigans\SingleTableInheritance;
 
+use Illuminate\Events\Dispatcher;
+
 use Nanigans\SingleTableInheritance\Exceptions\SingleTableInheritanceException;
 use Nanigans\SingleTableInheritance\Exceptions\SingleTableInheritanceInvalidAttributesException;
 
@@ -29,6 +31,9 @@ trait SingleTableInheritanceTrait {
    * @return void
    */
   public static function bootSingleTableInheritanceTrait() {
+    if (static::getEventDispatcher() === null) {
+      static::setEventDispatcher(new Dispatcher());
+    }
 
     static::getSingleTableTypeMap();
     static::getAllPersistedAttributes();


### PR DESCRIPTION
The trait does not work correctly when using standalone Eloquent. Events are not fired and the class type is not set. The full version of Laravel sets an event dispatcher but that doesn't happen with standalone Eloquent. Therefore, when booting, we check for a dispatcher. If one doesn't exist, it's created and registered with Eloquent.